### PR TITLE
Add 'execute' method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,13 @@ export default class ReCaptcha extends Component {
 		);
 	}
 
+		execute = () => {
+			if (isRecaptchaLoaded() && this.element && this.recaptchaId !== null) {
+				return grecaptcha.execute(this.recaptchaId);
+			}
+			return null;
+		}
+
 		getResponse = () => {
 			if (isRecaptchaLoaded() && this.element && this.recaptchaId !== null) {
 				return grecaptcha.getResponse(this.recaptchaId);


### PR DESCRIPTION
Resolves issue #1.

Implement Google Invisible captcha execute method.

Tested with linter and karma, also tested manually using example/index.js.