### PR TITLE
Fix multiple recaptcha bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,8 +31,10 @@ export default class ReCaptcha extends Component {
 		if (isRecaptchaLoaded() && this.element && this.recaptchaId !== null) {
 			this.removeRecaptcha();
 		}
-		window.___grecaptcha_cfg.count = 0;
-		window.___grecaptcha_cfg.clients = {};
+		if ( window.___grecaptcha_cfg ) {
+		    delete ___grecaptcha_cfg.clients[this.recaptchaId];
+		    ___grecaptcha_cfg.count--;
+		}
 	}
 
 	render() {


### PR DESCRIPTION
There was bug when multiple ReCaptcha creates and then removes all of them.
`Error: Invalid ReCAPTCHA client id: 0`

Bug exists because when first ReCaptcha component unmounts, it clears all others reCaptchas from `___grecaptcha_cfg` object